### PR TITLE
Add support for custom user-agent string

### DIFF
--- a/rdrview.1
+++ b/rdrview.1
@@ -10,6 +10,7 @@ rdrview \- extract readable content from a webpage
 .RB [ -v ]
 [\fB-u \fIbase-url\fR]
 [\fB-E \fIencoding\fR]
+[\fB-A \fIuser-agent\fR]
 [\fB-T \fItemplate\fR]
 [\fB-c\fR|\fB-H\fR|\fB\-M\fR|\fB\-B \fIbrowser\fR]
 [\fIpath\fR|\fIurl\fR]
@@ -72,6 +73,9 @@ Specify a browser to display the result.
 Specify the character encoding of the source.
 By default,
 the meta tags will be checked.
+.TP
+\fB\-A \fIuser-agent\fR, \fB--agent=\fIuser-agent
+Specify user-agent string.
 .TP
 .BR \-H ", " \-\-html
 Output the raw HTML for the extracted article.

--- a/src/rdrview.h
+++ b/src/rdrview.h
@@ -32,6 +32,9 @@
 #include <libxml/HTMLtree.h>
 #include <libxml/debugXML.h>
 
+/* Default user-agent. The Incapsula CDN demands user-agent strings of a certain form */
+#define RDRVIEW_DEFAULT_USER_AGENT "Mozilla/5.0 rdrview/0.1"
+
 /* Cli options, plus some internal configuration */
 struct options {
 	unsigned int flags;
@@ -40,6 +43,7 @@ struct options {
 	const char *template; /* Fields to include in the extracted article */
 	const char *base_url;
 	const char *browser;
+	const char *agent;
 	const char *url;
 	FILE *localfile; /* Used only if the "url" is actually a local path */
 };


### PR DESCRIPTION
By default, rdrview will user own user-agent which can't be
changed. However, some sites will refuse access if user-agent is not
"usual" one, like firefox/chromium/etc.

Also, some sites can alter (even simplify) the content if user-agent
is changed, which can make rdrview render it more easily.