### PR TITLE
fix OpenBSD compiler command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 SYSTEM = $(shell uname)
-CC = gcc
+ifeq ($(SYSTEM), OpenBSD)
+	CC := egcc
+else
+	CC := gcc
+endif
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
 
 CFLAGS = -DNDEBUG -O2 -Wall -Wextra -fno-strict-aliasing

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ ifeq ($(SYSTEM), Linux)
 	LDLIBS += -lseccomp
 else ifeq ($(SYSTEM), FreeBSD)
 	LDLIBS += -liconv
+else ifeq ($(SYSTEM), OpenBSD)
+	LDLIBS += -liconv
 else ifeq ($(SYSTEM), Darwin)
 	LDLIBS += -liconv
 endif

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To build _rdrview_ on the BSDs, you will need GNU make as well as the libraries.
 Having a terminal browser available is recommended. On OpenBSD, become root and
 run
 
-    pkg_add gmake curl libxml lynx
+    pkg_add gmake gcc libxml curl lynx
 
 On FreeBSD, that would be
 


### PR DESCRIPTION
On OpenBSD 7.1 `gcc` is installed as `egcc`
```
pkg_info -L gcc
...
/usr/local/bin/egcc
...
```

With original `Makefile` you get:
```
gmake: gcc: No such file or directory
```

Make `Makefile` aware of it

---

Also, original `README.md` doesn't mention the `gcc` among tools to be installed