### PR TITLE
Add missing include with libxml2 2.12+

### DIFF
--- a/src/rdrview.h
+++ b/src/rdrview.h
@@ -26,6 +26,7 @@
 #define RDRVIEW_H
 
 #include <assert.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <sys/types.h>
 #include <regex.h>


### PR DESCRIPTION
libxml2 2.12 removed extra includes, which causes stdlib.h to not get implicitly included anymore.

The missing include results in a warning on gcc13 and below with the resulting binary truncating the pointer to an integer, gcc14+ makes this a hard error.

e.g.
```
src/content.c: In function 'trim_and_unescape':
src/content.c:54:19: error: implicit declaration of function 'malloc' [-Werror=implicit-function-declaration]
   54 |         trimmed = malloc(strlen(start) + 1);
      |                   ^~~~~~
src/content.c:28:1: note: include '<stdlib.h>' or provide a declaration of 'malloc'
   27 | #include "rdrview.h"
  +++ |+#include <stdlib.h>
   28 | 
src/content.c:54:19: warning: incompatible implicit declaration of built-in function 'malloc' [-Wbuiltin-declaration-mismatch]
   54 |         trimmed = malloc(strlen(start) + 1);
      |                   ^~~~~~
src/content.c:54:19: note: include '<stdlib.h>' or provide a declaration of 'malloc'
src/content.c:80:33: error: implicit declaration of function 'atoi' [-Werror=implicit-function-declaration]
   80 |                         *dest = atoi(src);
      |                                 ^~~~
src/content.c:90:9: error: implicit declaration of function 'free' [-Werror=implicit-function-declaration]
   90 |         free(*str);
      |         ^~~~
src/content.c:90:9: note: include '<stdlib.h>' or provide a declaration of 'free'
...
```