### PR TITLE
Change CC to cc on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SYSTEM = $(shell uname)
 ifeq ($(SYSTEM), OpenBSD)
-	CC := egcc
+	CC := cc
 else
 	CC := gcc
 endif


### PR DESCRIPTION
`rdrview` compiles on OpenBSD but only when the Makefile is edited to make `CC := cc`.

~ $ uname
OpenBSD

~ $ which egcc
which: egcc: Command not found.

2 ~ $ which gcc
which: gcc: Command not found.

2 ~ $ which cc
/usr/bin/cc