### PR TITLE
Handle (remove) zero-width-space

### DIFF
--- a/src/content.c
+++ b/src/content.c
@@ -104,6 +104,11 @@ void strcpy_normalize(xmlChar *dest, const xmlChar *src)
 			*dest = ' ';
 			src += isspace(*src) ? 1 : 2;
 		}
+		/* Skip zero-width space (U+200B) */
+		if (memcmp(src, "\xe2\x80\x8b", 3) == 0) {
+			--dest;   // Don't copy it
+			src += 2; // Skip the extra bytes
+		}
 		if (*dest == ' ')
 			--src;
 	}


### PR DESCRIPTION
We currently end up converting zero-width-space (zws) U+200B / \xe2\x8\x8b
to an invalid sequence (FD BF BF BD A3 AC). We (chatgpt and I) added code to
just remove these.